### PR TITLE
Normalize responsive headline font-size

### DIFF
--- a/src/components/layouts/article_header.vue
+++ b/src/components/layouts/article_header.vue
@@ -62,7 +62,7 @@ export default {
 
 @media only screen and (max-width: 800px) {
   .project-headline {
-    font-size: 2.5rem;
+    font-size: 2rem;
   }
   .tagline {
     font-size: 1.5rem;


### PR DESCRIPTION
- reduced from 2.5rem to 2rem @ 800px